### PR TITLE
Extend SendPresence() stub func to allow send useful statuses

### DIFF
--- a/xmpp.go
+++ b/xmpp.go
@@ -1085,7 +1085,48 @@ func (c *Client) SendOrg(org string) (n int, err error) {
 }
 
 func (c *Client) SendPresence(presence Presence) (n int, err error) {
-	return fmt.Fprintf(c.stanzaWriter, "<presence from='%s' to='%s'/>", xmlEscape(presence.From), xmlEscape(presence.To))
+	// Forge opening presence tag
+	var buf string = "<presence"
+
+	if presence.From != "" {
+		buf = buf + fmt.Sprintf(" from='%s'", xmlEscape(presence.From))
+	}
+
+	if presence.To != "" {
+		buf = buf + fmt.Sprintf(" to='%s'", xmlEscape(presence.To))
+	}
+
+	if presence.Type != "" {
+		// https://www.ietf.org/rfc/rfc3921.txt, 2.2.1, types can only be
+		// unavailable, subscribe, subscribed, unsubscribe, unsubscribed, probe, error
+		switch presence.Type {
+		case "unavailable", "subscribe", "subscribed", "unsubscribe", "unsubscribed", "probe", "error":
+			buf = buf + fmt.Sprintf(" type='%s'", xmlEscape(presence.Type))
+		}
+	}
+
+	buf = buf + ">"
+
+	// TODO: there may be optional tag "priority", but former presence type does not take this into account
+	//       so either we must follow std, change type xmpp.Presence and break backward compatibility
+	//       or leave it as-is and potentially break client software
+
+	if presence.Show != "" {
+		// https://www.ietf.org/rfc/rfc3921.txt 2.2.2.1, show can be only
+		// away, chat, dnd, xa
+		switch presence.Show {
+		case "away", "chat", "dnd", "xa":
+			buf = buf + fmt.Sprintf("<show>%s</show>", xmlEscape(presence.Show))
+		}
+	}
+
+	if presence.Status != "" {
+		buf = buf + fmt.Sprintf("<status>%s</status>", xmlEscape(presence.Status))
+	}
+
+	buf = buf + "</presence>"
+
+	return fmt.Fprint(c.StanzaWriter, buf)
 }
 
 // SendKeepAlive sends a "whitespace keepalive" as described in chapter 4.6.1 of RFC6120.

--- a/xmpp.go
+++ b/xmpp.go
@@ -55,7 +55,6 @@ var DefaultConfig = &tls.Config{}
 
 // DebugWriter is the writer used to write debugging output to.
 var DebugWriter io.Writer = os.Stderr
-var StanzaWriter io.Writer
 
 // Cookie is a unique XMPP session identifier
 type Cookie uint64

--- a/xmpp_information_query.go
+++ b/xmpp_information_query.go
@@ -35,13 +35,13 @@ func (c *Client) DiscoverEntityItems(jid string) (string, error) {
 // RawInformationQuery sends an information query request to the server.
 func (c *Client) RawInformationQuery(from, to, id, iqType, requestNamespace, body string) (string, error) {
 	const xmlIQ = "<iq from='%s' to='%s' id='%s' type='%s'><query xmlns='%s'>%s</query></iq>"
-	_, err := fmt.Fprintf(StanzaWriter, xmlIQ, xmlEscape(from), xmlEscape(to), id, iqType, requestNamespace, body)
+	_, err := fmt.Fprintf(c.stanzaWriter, xmlIQ, xmlEscape(from), xmlEscape(to), id, iqType, requestNamespace, body)
 	return id, err
 }
 
 // rawInformation send a IQ request with the payload body to the server
 func (c *Client) RawInformation(from, to, id, iqType, body string) (string, error) {
 	const xmlIQ = "<iq from='%s' to='%s' id='%s' type='%s'>%s</iq>"
-	_, err := fmt.Fprintf(StanzaWriter, xmlIQ, xmlEscape(from), xmlEscape(to), id, iqType, body)
+	_, err := fmt.Fprintf(c.stanzaWriter, xmlIQ, xmlEscape(from), xmlEscape(to), id, iqType, body)
 	return id, err
 }

--- a/xmpp_muc.go
+++ b/xmpp_muc.go
@@ -25,7 +25,7 @@ const (
 
 // Send sends room topic wrapped inside an XMPP message stanza body.
 func (c *Client) SendTopic(chat Chat) (n int, err error) {
-	return fmt.Fprintf(StanzaWriter, "<message to='%s' type='%s' xml:lang='en'>"+"<subject>%s</subject></message>",
+	return fmt.Fprintf(c.stanzaWriter, "<message to='%s' type='%s' xml:lang='en'>"+"<subject>%s</subject></message>",
 		xmlEscape(chat.Remote), xmlEscape(chat.Type), xmlEscape(chat.Text))
 }
 
@@ -33,7 +33,7 @@ func (c *Client) JoinMUCNoHistory(jid, nick string) (n int, err error) {
 	if nick == "" {
 		nick = c.jid
 	}
-	return fmt.Fprintf(StanzaWriter, "<presence to='%s/%s'>\n"+
+	return fmt.Fprintf(c.stanzaWriter, "<presence to='%s/%s'>\n"+
 		"<x xmlns='%s'>"+
 		"<history maxchars='0'/></x>\n"+
 		"</presence>",
@@ -47,31 +47,31 @@ func (c *Client) JoinMUC(jid, nick string, history_type, history int, history_da
 	}
 	switch history_type {
 	case NoHistory:
-		return fmt.Fprintf(StanzaWriter, "<presence to='%s/%s'>\n"+
+		return fmt.Fprintf(c.stanzaWriter, "<presence to='%s/%s'>\n"+
 			"<x xmlns='%s' />\n"+
 			"</presence>",
 			xmlEscape(jid), xmlEscape(nick), nsMUC)
 	case CharHistory:
-		return fmt.Fprintf(StanzaWriter, "<presence to='%s/%s'>\n"+
+		return fmt.Fprintf(c.stanzaWriter, "<presence to='%s/%s'>\n"+
 			"<x xmlns='%s'>\n"+
 			"<history maxchars='%d'/></x>\n"+
 			"</presence>",
 			xmlEscape(jid), xmlEscape(nick), nsMUC, history)
 	case StanzaHistory:
-		return fmt.Fprintf(StanzaWriter, "<presence to='%s/%s'>\n"+
+		return fmt.Fprintf(c.stanzaWriter, "<presence to='%s/%s'>\n"+
 			"<x xmlns='%s'>\n"+
 			"<history maxstanzas='%d'/></x>\n"+
 			"</presence>",
 			xmlEscape(jid), xmlEscape(nick), nsMUC, history)
 	case SecondsHistory:
-		return fmt.Fprintf(StanzaWriter, "<presence to='%s/%s'>\n"+
+		return fmt.Fprintf(c.stanzaWriter, "<presence to='%s/%s'>\n"+
 			"<x xmlns='%s'>\n"+
 			"<history seconds='%d'/></x>\n"+
 			"</presence>",
 			xmlEscape(jid), xmlEscape(nick), nsMUC, history)
 	case SinceHistory:
 		if history_date != nil {
-			return fmt.Fprintf(StanzaWriter, "<presence to='%s/%s'>\n"+
+			return fmt.Fprintf(c.stanzaWriter, "<presence to='%s/%s'>\n"+
 				"<x xmlns='%s'>\n"+
 				"<history since='%s'/></x>\n"+
 				"</presence>",
@@ -88,28 +88,28 @@ func (c *Client) JoinProtectedMUC(jid, nick string, password string, history_typ
 	}
 	switch history_type {
 	case NoHistory:
-		return fmt.Fprintf(StanzaWriter, "<presence to='%s/%s'>\n"+
+		return fmt.Fprintf(c.stanzaWriter, "<presence to='%s/%s'>\n"+
 			"<x xmlns='%s'>\n"+
 			"<password>%s</password>"+
 			"</x>\n"+
 			"</presence>",
 			xmlEscape(jid), xmlEscape(nick), nsMUC, xmlEscape(password))
 	case CharHistory:
-		return fmt.Fprintf(StanzaWriter, "<presence to='%s/%s'>\n"+
+		return fmt.Fprintf(c.stanzaWriter, "<presence to='%s/%s'>\n"+
 			"<x xmlns='%s'>\n"+
 			"<password>%s</password>\n"+
 			"<history maxchars='%d'/></x>\n"+
 			"</presence>",
 			xmlEscape(jid), xmlEscape(nick), nsMUC, xmlEscape(password), history)
 	case StanzaHistory:
-		return fmt.Fprintf(StanzaWriter, "<presence to='%s/%s'>\n"+
+		return fmt.Fprintf(c.stanzaWriter, "<presence to='%s/%s'>\n"+
 			"<x xmlns='%s'>\n"+
 			"<password>%s</password>\n"+
 			"<history maxstanzas='%d'/></x>\n"+
 			"</presence>",
 			xmlEscape(jid), xmlEscape(nick), nsMUC, xmlEscape(password), history)
 	case SecondsHistory:
-		return fmt.Fprintf(StanzaWriter, "<presence to='%s/%s'>\n"+
+		return fmt.Fprintf(c.stanzaWriter, "<presence to='%s/%s'>\n"+
 			"<x xmlns='%s'>\n"+
 			"<password>%s</password>\n"+
 			"<history seconds='%d'/></x>\n"+
@@ -117,7 +117,7 @@ func (c *Client) JoinProtectedMUC(jid, nick string, password string, history_typ
 			xmlEscape(jid), xmlEscape(nick), nsMUC, xmlEscape(password), history)
 	case SinceHistory:
 		if history_date != nil {
-			return fmt.Fprintf(StanzaWriter, "<presence to='%s/%s'>\n"+
+			return fmt.Fprintf(c.stanzaWriter, "<presence to='%s/%s'>\n"+
 				"<x xmlns='%s'>\n"+
 				"<password>%s</password>\n"+
 				"<history since='%s'/></x>\n"+
@@ -130,6 +130,6 @@ func (c *Client) JoinProtectedMUC(jid, nick string, password string, history_typ
 
 // xep-0045 7.14
 func (c *Client) LeaveMUC(jid string) (n int, err error) {
-	return fmt.Fprintf(StanzaWriter, "<presence from='%s' to='%s' type='unavailable' />",
+	return fmt.Fprintf(c.stanzaWriter, "<presence from='%s' to='%s' type='unavailable' />",
 		c.jid, xmlEscape(jid))
 }

--- a/xmpp_ping.go
+++ b/xmpp_ping.go
@@ -11,7 +11,7 @@ func (c *Client) PingC2S(jid, server string) error {
 	if server == "" {
 		server = c.domain
 	}
-	_, err := fmt.Fprintf(StanzaWriter, "<iq from='%s' to='%s' id='c2s1' type='get'>\n"+
+	_, err := fmt.Fprintf(c.stanzaWriter, "<iq from='%s' to='%s' id='c2s1' type='get'>\n"+
 		"<ping xmlns='urn:xmpp:ping'/>\n"+
 		"</iq>",
 		xmlEscape(jid), xmlEscape(server))
@@ -19,7 +19,7 @@ func (c *Client) PingC2S(jid, server string) error {
 }
 
 func (c *Client) PingS2S(fromServer, toServer string) error {
-	_, err := fmt.Fprintf(StanzaWriter, "<iq from='%s' to='%s' id='s2s1' type='get'>\n"+
+	_, err := fmt.Fprintf(c.stanzaWriter, "<iq from='%s' to='%s' id='s2s1' type='get'>\n"+
 		"<ping xmlns='urn:xmpp:ping'/>\n"+
 		"</iq>",
 		xmlEscape(fromServer), xmlEscape(toServer))
@@ -27,7 +27,7 @@ func (c *Client) PingS2S(fromServer, toServer string) error {
 }
 
 func (c *Client) SendResultPing(id, toServer string) error {
-	_, err := fmt.Fprintf(StanzaWriter, "<iq type='result' to='%s' id='%s'/>",
+	_, err := fmt.Fprintf(c.stanzaWriter, "<iq type='result' to='%s' id='%s'/>",
 		xmlEscape(toServer), xmlEscape(id))
 	return err
 }

--- a/xmpp_subscription.go
+++ b/xmpp_subscription.go
@@ -5,12 +5,12 @@ import (
 )
 
 func (c *Client) ApproveSubscription(jid string) {
-	fmt.Fprintf(StanzaWriter, "<presence to='%s' type='subscribed'/>",
+	fmt.Fprintf(c.stanzaWriter, "<presence to='%s' type='subscribed'/>",
 		xmlEscape(jid))
 }
 
 func (c *Client) RevokeSubscription(jid string) {
-	fmt.Fprintf(StanzaWriter, "<presence to='%s' type='unsubscribed'/>",
+	fmt.Fprintf(c.stanzaWriter, "<presence to='%s' type='unsubscribed'/>",
 		xmlEscape(jid))
 }
 
@@ -20,6 +20,6 @@ func (c *Client) RetrieveSubscription(jid string) {
 }
 
 func (c *Client) RequestSubscription(jid string) {
-	fmt.Fprintf(StanzaWriter, "<presence to='%s' type='subscribe'/>",
+	fmt.Fprintf(c.stanzaWriter, "<presence to='%s' type='subscribe'/>",
 		xmlEscape(jid))
 }


### PR DESCRIPTION
Make use of Presence.{Type,Show,Status} fields in SendPresence() to send actual client status to server and chat rooms.